### PR TITLE
Added p-values to non-cum plot, and some cosemetic changes

### DIFF
--- a/bin/hdfcoinc/pycbc_page_snrifar
+++ b/bin/hdfcoinc/pycbc_page_snrifar
@@ -5,12 +5,29 @@ import argparse, h5py, numpy, logging, sys, lal
 import matplotlib
 matplotlib.use('Agg')
 import pylab, pycbc.results, pycbc.version
-from scipy.special import erf
+from scipy.special import erfc
 
 def p_from_sigma(sig):
-    return 1 - (1 - erf(sig / 2**0.5)) / 2
-    
+    return erfc((sig)/numpy.sqrt(2))/2.
+
+def p_from_far(far, livetime):
+    return 1 - numpy.exp(-far * livetime)
+
+def _far_from_p(p, livetime, max_far):
+    if p < 0.0001:
+        lmbda = p + p**2./2.
+    elif p == 1:
+        return max_far
+    else:
+        lmbda = -numpy.log(1-p)
+    far = lmbda/livetime
+    if far > max_far:
+        return max_far
+    return far
+far_from_p = numpy.vectorize(_far_from_p)
+
 pylab.rc('text', usetex=True)
+pylab.rc('font', **{'family': 'serif', 'serif': ['Computer Modern']})
 
 parser = argparse.ArgumentParser()
 # General required options
@@ -22,6 +39,10 @@ parser.add_argument('--trials-factor', type=int, default=1)
 parser.add_argument('--not-cumulative', action='store_true')
 parser.add_argument('--closed-box', action='store_true',
       help="Make a closed box version that excludes foreground triggers")
+parser.add_argument('--xmin', type=float, help='Set the minimum value of the x-axis')
+parser.add_argument('--xmax', type=float, help='Set the maximum value of the x-axis')
+parser.add_argument('--ymin', type=float, help='Set the minimum value of the y-axis (in units of 1/years)')
+parser.add_argument('--ymax', type=float, help='Set the maximum value of the y-axis (in units of 1/years)')
 args = parser.parse_args()
 
 args.cumulative = not args.not_cumulative
@@ -33,20 +54,21 @@ if args.verbose:
 logging.info('Read in the data')
 f = h5py.File(args.trigger_file, 'r')
 
+foreground_livetime = f.attrs['foreground_time'] / lal.YRJUL_SI
 try:
     cstat_fore = f['foreground/stat'][:]
     
     if args.cumulative:
         cstat_fore.sort()
-        cstat_rate = numpy.arange(len(cstat_fore), 0, -1) / f.attrs['foreground_time'] * 3.15569e7
+        cstat_rate = numpy.arange(len(cstat_fore), 0, -1) / f.attrs['foreground_time'] * 3.15569e7 \
+            * args.trials_factor
     else:
         ssort = cstat_fore.argsort()
-        cstat_rate = 1.0 / f['foreground/ifar'][:]
+        cstat_rate = 1.0 / f['foreground/ifar'][:] * args.trials_factor
         cstat_rate = cstat_rate[ssort]
         cstat_fore = cstat_fore[ssort]
+        cstat_fap = p_from_far(cstat_rate, foreground_livetime)
     
-    cstat_rate *= args.trials_factor
-        
     logging.info('Found %s foreground triggers' % len(cstat_fore))
 except:
     cstat_fore = None
@@ -56,6 +78,18 @@ cstat_back = f['background/stat'][:]
 back_sort = cstat_back.argsort()
 cstat_back = cstat_back[back_sort]
 far_back = 1.0 / back_ifar[back_sort] * args.trials_factor
+fap_back = p_from_far(far_back, foreground_livetime)
+
+# we'll use the background far for the ylimits
+if args.ymin is None:
+    plot_ymin = far_back.min()/10.
+else:
+    plot_ymin = args.ymin
+
+if args.ymax is None:
+    plot_ymax = far_back.max()
+else:
+    plot_ymax = args.ymax
 
 logging.info('Found %s background (inclusive zerolag) triggers' % len(cstat_back))
 
@@ -66,8 +100,29 @@ cstat_back_exc = cstat_back_exc[back_sort_exc]
 far_back_exc = 1.0 / back_ifar_exc[back_sort_exc] * args.trials_factor
 logging.info('Found %s background (exclusive zerolag) triggers' % len(cstat_back_exc))
 
+# we'll us the background for the xlimits if closed box,
+# foreground otherwise
+if args.xmin is not None:
+    plot_xmin = args.xmin
+elif args.closed_box:
+    plot_xmin = cstat_back_exc.min()
+else:
+    plot_xmin = cstat_fore.min()
+
+if args.xmax is not None:
+    plot_xmax = args.xmax
+# otherwise, make the furthest point to the right be ~1/10 of the
+# width of the plot from the right axis
+else:
+    if args.closed_box:
+        plot_xmax = cstat_back_exc.max()
+    else:
+        plot_xmax = max(cstat_back.max(), cstat_fore.max())
+    plot_xmax += (plot_xmax - plot_xmin)/10.
+
 fig = pylab.figure(1)
-pylab.scatter(cstat_back_exc, far_back_exc, color='grey', marker='.', s=3, label='Closed Box Background')
+back_marker = 'x'
+pylab.scatter(cstat_back_exc, far_back_exc, color='gray', marker=back_marker, s=10, label='Closed Box Background')
 
 def pretty_num(num):
     exp = numpy.floor(numpy.log10(num))
@@ -75,18 +130,16 @@ def pretty_num(num):
     return '%2.1fe%.0f' % (val, exp)
 
 if not args.closed_box:
-    pylab.scatter(cstat_back, far_back, color='black', marker='.', s=3, label='Open Box Background')
+    pylab.scatter(cstat_back, far_back, color='black', marker=back_marker, s=10,
+        label='Open Box Background')
 
     if cstat_fore is not None and len(cstat_fore):
         pylab.scatter(cstat_fore, cstat_rate, s=60, color='#ff6600',
                                   marker='d', label='Foreground', zorder=100,
-                                  linewidth=0.3, edgecolors='white')
-        pylab.xlim(cstat_back.min(), max(cstat_fore.max(), cstat_back.max()) + 1)
-    else:
-        pylab.xlim(cstat_back.min(), cstat_back.max() + 1)
+                                  linewidth=0.5, edgecolors='white')
 
-    sigmas = numpy.array([5, 4, 3, 2, 1])
     if args.cumulative:
+        sigmas = numpy.array([5, 4, 3, 2, 1])
         top = cstat_rate.max()
         for i in range(len(sigmas) - 1):
             p1 = p_from_sigma(sigmas[i])
@@ -99,8 +152,8 @@ if not args.closed_box:
             else:
                 offset = 0
                 
-            low = far_back / (1 - p2) * args.trials_factor + offset
-            high = far_back / (1 - p1) * args.trials_factor + offset
+            low = far_back / p2 * args.trials_factor + offset
+            high = far_back / p1 * args.trials_factor + offset
             pylab.fill_between(cstat_back, low, high,
                                linewidth=0, color=pylab.cm.Blues(sigmas[i] / 5.0), zorder=-1)
 
@@ -110,56 +163,104 @@ if not args.closed_box:
             
 
     else:
-        p = p_from_sigma(sigmas)
-        far = (1 - p) / f.attrs['foreground_time'] * lal.YRJUL_SI
+        # add arrows to any points > the loudest background
+        louder_pts = numpy.where(cstat_fore > cstat_back.max())[0] 
+        for ii in louder_pts:
+            r = cstat_fore[ii]
+            arr_start = cstat_rate[ii]
+            # make the arrow length 1/15 the height of the plot
+            arr_end = arr_start * (plot_ymin/plot_ymax)**(1./15)
+            pylab.plot([r, r], [arr_start, arr_end], lw=2, color='#ff6600',
+                zorder=99)
+            pylab.plot([r, r], [arr_start, arr_end], lw=2.6, color='white',
+                zorder=97)
+            pylab.scatter([r], [arr_end], marker='v', c='#ff6600',
+                edgecolors='white', lw=0.5, s=40, zorder=98)
         
-        far = numpy.append(far, [1.0 / f.attrs['foreground_time'] * lal.YRJUL_SI])
-        
-        ylocs, ylabels = [], []
-        for i in range(len(far) - 1):
-            pylab.axhspan(far[i], far[i+1],
-                          linewidth=0, color=pylab.cm.Blues(sigmas[i] / 5.0), alpha=0.3, zorder=-1) 
-        
-        if cstat_fore is not None and len(cstat_fore): 
-            pylab.plot(cstat_fore[-1], cstat_rate[-1] / 3, 'ko', marker="$\downarrow$", markersize=20)   
-        
-        ax1 = pylab.gca()
-        ax2 = ax1.twinx()
-        
-        sigmas = ['%1.0f$\sigma$' % sig for sig in sigmas]
-        
+if not args.cumulative:
+    # add second y-axis for probabilities, sigmas
+    sigmas = numpy.arange(6)+1
+    ax1 = pylab.gca()
+    ax1.set_axis_bgcolor('none')
+    ax2 = ax1.twinx()
+    ax1.set_zorder(ax2.get_zorder()+1) # put axis1 on top
+    pylab.sca(ax2)
+    # where to stick the sigma lables; we'll put them 1/25th from the
+    # right axis
+    anntx = plot_xmax - (plot_xmax - plot_xmin)/25.
+    sigps = p_from_sigma(sigmas)
+    for ii,p in enumerate(sigps[:-1]):
+        nextp = sigps[ii+1]
+        pylab.axhspan(far_from_p(nextp, foreground_livetime, far_back.max()),
+                    far_from_p(p, foreground_livetime, far_back.max()),
+                    linewidth=0,
+                    color=pylab.cm.Blues(float(sigmas[ii+1]) / sigmas.size),
+                    alpha=0.3, zorder=-1) 
+        # add sigma label
+        pylab.annotate('%1.0f$\sigma$' % sigmas[ii],
+                       (anntx, far_from_p(p, foreground_livetime,
+                        far_back.max())), zorder=100)
+
+
         pylab.sca(ax1)
     
 if args.cumulative:
-    pylab.ylabel('Cumulative Rate $(yr^{-1})$')   
+    pylab.ylabel('Cumulative Rate (yr$^{-1}$)')   
 else:
     if args.trials_factor == 1:
-        pylab.ylabel('False Alarm Rate $(yr^{-1})$')
+        pylab.ylabel('False Alarm Rate (yr$^{-1}$)')
     elif args.trials_factor >= 1:
-        pylab.ylabel('Combined False Alarm Rate $(yr^{-1})$')
+        pylab.ylabel('Combined False Alarm Rate (yr$^{-1}$)')
+    ax2.set_ylabel('False Alarm Probability')
 
-pylab.xlabel('Weighted Network SNR')
+pylab.xlabel(r'Network Re-weighted SNR, $\hat{\rho}_c$')
 pylab.yscale('log')
-pylab.ylim(far_back.min() / 10.0, far_back.max())
+pylab.ylim(plot_ymin, plot_ymax)
+pylab.xlim(plot_xmin, plot_xmax)
 
 if args.cumulative:
     pylab.legend(loc="lower left")
+    pylab.grid()
 else:
     pylab.legend(loc="upper right")
     ax2.set_yscale('log')
-    ax2.set_ylim(ax1.get_ylim())
-    ax2.set_yticks(far)
-    ax2.set_yticklabels(sigmas)
-    
-pylab.grid()
+    ymin, ymax = ax1.get_ylim()
+    ax2.set_ylim(ymin, ymax)
+    # we'll put ticks at faps of 10^{-x}, where x is an integer
+    # get the ymin, ymax in terms of probability
+    pymin = p_from_far(ymin, foreground_livetime)
+    pymax = p_from_far(ymax, foreground_livetime)
+    # figure out the range of values we need to plot: this will be the
+    # floor/ceil of the min/max
+    # values
+    tick_min = numpy.ceil(numpy.log10(pymin))
+    tick_max = numpy.floor(numpy.log10(pymax))
+    # tick ranges
+    pticks = numpy.arange(tick_min, tick_max+1)
+    # convert back to FAR
+    fticks = far_from_p(10**pticks, foreground_livetime, far_back.max())
+    ax2.set_yticks(fticks)
+    # set the labels
+    ax2.set_yticklabels(['$10^{%i}$' %(val) for val in pticks.astype(int)])
+    # add minor ticks
+    N_minor_per_decade = 10.
+    pminorticks = numpy.zeros(N_minor_per_decade * (pticks.size-1))
+    for ii,p in enumerate(10**pticks[:-1]):
+        idx = ii*N_minor_per_decade
+        pminorticks[idx:idx+N_minor_per_decade] = \
+            p * numpy.arange(1,N_minor_per_decade+1).astype(float)
+    fminorticks = far_from_p(pminorticks, foreground_livetime, far_back.max())
+    ax2.set_yticks(fminorticks, minor=True)
+
 
 pycbc.results.save_fig_with_metadata(fig, args.output_file,
      title="%s bin, FAR vs Rank" % f.attrs['name'] if 'name' in f.attrs else "FAR vs Rank", 
      caption="Mapping between the ranking statistic and false alarm rate: "
-             "Orange triangles (if present) represent triggers from the "
+             "Orange diamonds (if present) represent triggers from the "
              " zero-lag (foreground) analysis. Solid crosses show "
              "the background inclusive of zerolag events, and grey crosses show the "
              " background constructed without triggers that are"
              " coincident in the zero-lag data.",
      cmd=' '.join(sys.argv))
              
+pylab.savefig(args.output_file, dpi=300, bbox_limits='tight')


### PR DESCRIPTION
This adds the p-values to the non-cumulative page_snrifar plot, along with some cosemetic changes. I've tested the 4 possible plots this can make (note: to view these plots, you need LVC credentials):
- [the (new) non-cumulative open box](https://atlas1.atlas.aei.uni-hannover.de/~cdcapano/LSC/O1/er8/er8b/c00-16day_duncan/test2/er8b_test-non_cumulative.png)
- [the non-cumulative closed box](https://atlas1.atlas.aei.uni-hannover.de/~cdcapano/LSC/O1/er8/er8b/c00-16day_duncan/test2/er8b_test-closed_box_non_cumulative.png)
- [the cumulative open box](https://atlas1.atlas.aei.uni-hannover.de/~cdcapano/LSC/O1/er8/er8b/c00-16day_duncan/test2/er8b_test-cumulative.png)
- [the cumulative closed box](https://atlas1.atlas.aei.uni-hannover.de/~cdcapano/LSC/O1/er8/er8b/c00-16day_duncan/test2/er8b_test-closed_box_cumulative.png)
