### PR TITLE
 add support for injection-window handling in pycbc_inspiral_fir

### DIFF
--- a/bin/pycbc_inspiral_fir
+++ b/bin/pycbc_inspiral_fir
@@ -183,6 +183,9 @@ def main():
                                          inj_filter_rejector=inj_filter_rejector)
         
         strain_segments = pycbc.strain.StrainSegments.from_cli(args, gwstrain)
+
+        if hasattr(gwstrain, "injections"):
+            strain_segments.injections = gwstrain.injections
         
         tlen = strain_segments.time_len
         flen = strain_segments.freq_len
@@ -273,6 +276,9 @@ def main():
             logging.info(f"  Ratio Batch {i+1}/{n_coarse}, {len(taps)} FIR templates")
 
             for s_num, stilde in enumerate(segments):
+                if not inj_filter_rejector.template_segment_checker(
+                        bank, coarse_idx, stilde):
+                    continue
                 logging.info(f"Processing Segment {s_num}")
                 t1 = time.time()
 


### PR DESCRIPTION
<!---
This is a brief template for making pull requests for PyCBC.
This is _not_ a proscriptive template - you can use a different style if you want.
Please do think about the questions posed here and whether the details will be useful to include in your PR
Please add sufficient details so that people looking back at the request with no context around the work can understand the changes.
To choose reviewers, please look at the git blame for the code you are changing (if applicable),
or discuss in the #pycbc-code channel of the gwastro slack.
Please add labels as appropriate
-->

<!-- TOP-LEVEL SUMMARY: Please provide a brief, one-or-two-sentence description of the PR here
-->

## Support for handling injection-window in pycbc_inspiral_fir

<!--- Some basic info about the change (delete as appropriate) -->
This PR adds support for proper handling of injection windows in pycbc_inspiral_fir. Currently, SNRs are computed and stored for all trigger times. With this modification, trigger information is restricted to a window around the injection time, consistent with pycbc_inspiral's behavior. 


- [x] The author of this pull request confirms they will adhere to the [code of conduct](https://github.com/gwastro/pycbc/blob/master/CODE_OF_CONDUCT.md)
